### PR TITLE
If no extra_msg, don't append gratuitous `\n`

### DIFF
--- a/R/abort.R
+++ b/R/abort.R
@@ -151,12 +151,17 @@ abort_no_method_for_class <- function(fun, class, ...) {
   extra_msg <- list(...)
   if (any(purrr::map(extra_msg, is.character) == FALSE)) {
     abort_argument_type("...", must = "be character", not = ...)
-  } else {
-    extra_msg <- glue::glue_collapse(extra_msg, sep = "\n")
   }
+
+  if (length(extra_msg) > 0) {
+    extra_msg <- glue::glue_collapse(extra_msg, sep = "\n")
+  } else {
+    extra_msg <- character()
+  }
+
   if (length(class) > 1) {
     class <- glue::glue_collapse(
-     glue::glue("`{class}`"), sep = ", ", last = " and "
+      glue::glue("`{class}`"), sep = ", ", last = " and "
     )
     noun <- "classes"
   } else {


### PR DESCRIPTION
This PR adapts lvmisc for forward compatibility with glue. I will release glue no sooner than 2 weeks from now, so on March 31 (or likely a bit later).

In the next version of glue, `glue::glue_collapse()` will never return `character()` but instead will return `""` for empty inputs. For more detail see https://github.com/tidyverse/glue/pull/295.

In my hands, this PR makes lvmisc work as intended with released glue and dev glue.
